### PR TITLE
Digital ocean

### DIFF
--- a/AlumniProject/AlumniProject/AlumniProject/settings/dev.py
+++ b/AlumniProject/AlumniProject/AlumniProject/settings/dev.py
@@ -1,5 +1,4 @@
 from .settings import *
 
 DEBUG = True
-ALLOWED_HOSTS = ["127.0.0.1", "localhost", "0.0.0.0", 
-                 'alumni-association.dedyn.io']
+ALLOWED_HOSTS = ["127.0.0.1", "localhost", "0.0.0.0", "alumni-association.dedyn.io"]

--- a/AlumniProject/AlumniProject/AlumniProject/settings/dev.py
+++ b/AlumniProject/AlumniProject/AlumniProject/settings/dev.py
@@ -1,4 +1,5 @@
 from .settings import *
 
 DEBUG = True
-ALLOWED_HOSTS = ["127.0.0.1", "localhost", "0.0.0.0"]
+ALLOWED_HOSTS = ["127.0.0.1", "localhost", "0.0.0.0", 
+                 'alumni-association.dedyn.io']

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,13 +1,25 @@
 services:
-  web: 
+  web:
     build:
       context: AlumniProject
       target: builder
     volumes:
-      - ./AlumniProject:/AlumniProject  # Mount the entire project for live updates
-      - ./AlumniProject/db.sqlite3:/AlumniProject/db.sqlite3  
-    ports: 
-      - "8000:8000"
+      - ./AlumniProject:/AlumniProject
+      - ./AlumniProject/db.sqlite3:/AlumniProject/db.sqlite3
     environment:
-      - DEBUG=True  # make sure Django detects code changes
+      - DEBUG=True
+    expose:
+      - "8000"  # only exposed inside the docker network
     restart: unless-stopped
+
+  proxy:
+    image: nginx:latest
+    ports:
+      - "8080:8080"  # HTTPS (secure)
+      - "8000:8000"  # HTTP (for redirect)
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf
+      - /etc/letsencrypt:/etc/letsencrypt
+    restart: always
+    depends_on:
+      - web


### PR DESCRIPTION
Type of Change: New Feature

Summary:
This pull request sets up Docker reverse proxying and HTTPS support via nginx and Let’s Encrypt SSL certificates on our DigitalOcean droplet. This change allows us to access our web application securely at https://alumni-association.dedyn.io:8080 and ensures HTTP traffic on port 8000 is redirected to HTTPS.

We also updated the docker-compose.yml file to include a new proxy service and removed public port exposure from the web service to improve security. Additionally, we copied and modified the nginx.conf file from the ssl-test repository to route traffic to our Django server running inside the Docker network.

UI/UX Implementation
No changes made.

Model Updates
Data Models
No changes made.

Object-Oriented Models
No changes made.

End-to-End Testing Instructions
Navigate to the app in your browser at http://alumni-association.dedyn.io:8000
- Confirm that it redirects you to the secure version.

Navigate to https://alumni-association.dedyn.io:8080
- You should see the Django app load securely.

If you're seeing a DisallowedHost error, make sure the domain (alumni-association.dedyn.io) is listed in the Django ALLOWED_HOSTS setting and the app has been rebuilt with Docker Compose.