### PR TITLE
Added Necessary Change to the dev for the digital ocean to run properly

### DIFF
--- a/AlumniProject/AlumniProject/AlumniProject/settings/dev.py
+++ b/AlumniProject/AlumniProject/AlumniProject/settings/dev.py
@@ -2,13 +2,6 @@ from .settings import *
 
 DEBUG = True
 
-ALLOWED_HOSTS = [
-    "127.0.0.1",
-    "localhost",
-    "0.0.0.0",
-    "alumni-association.dedyn.io"
-]
+ALLOWED_HOSTS = ["127.0.0.1", "localhost", "0.0.0.0", "alumni-association.dedyn.io"]
 
-CSRF_TRUSTED_ORIGINS = [
-    "https://alumni-association.dedyn.io:8080"
-]
+CSRF_TRUSTED_ORIGINS = ["https://alumni-association.dedyn.io:8080"]

--- a/AlumniProject/AlumniProject/AlumniProject/settings/dev.py
+++ b/AlumniProject/AlumniProject/AlumniProject/settings/dev.py
@@ -1,4 +1,14 @@
 from .settings import *
 
 DEBUG = True
-ALLOWED_HOSTS = ["127.0.0.1", "localhost", "0.0.0.0", "alumni-association.dedyn.io"]
+
+ALLOWED_HOSTS = [
+    "127.0.0.1",
+    "localhost",
+    "0.0.0.0",
+    "alumni-association.dedyn.io"
+]
+
+CSRF_TRUSTED_ORIGINS = [
+    "https://alumni-association.dedyn.io:8080"
+]


### PR DESCRIPTION
This PR updates the dev.py settings file to fix a CSRF verification error when logging in via our secure domain (https://alumni-association.dedyn.io:8080). It adds the domain to the CSRF_TRUSTED_ORIGINS setting, ensuring Django allows form submissions from our custom URL. No other changes were made.