### PR TITLE
Added country code translation

### DIFF
--- a/AlumniProject/AlumniProject/social_tracker/tests/test_country_codes.py
+++ b/AlumniProject/AlumniProject/social_tracker/tests/test_country_codes.py
@@ -1,0 +1,19 @@
+from django.test import TestCase
+from social_tracker.utils.country_code_resolver import load_country_dict, get_country_name
+
+
+class CountryCodeTests(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.country_dict = load_country_dict()
+
+    def test_valid_country_code(self):
+        self.assertEqual(get_country_name(self.country_dict, 'US'), 'United States 🇺🇸')
+        self.assertEqual(get_country_name(self.country_dict, 'CA'), 'Canada 🇨🇦')
+
+    def test_invalid_country_code(self):
+        self.assertEqual(get_country_name(self.country_dict, 'ZZ'), 'Country code not found')
+
+    def test_partial_country_code(self):
+        self.assertEqual(get_country_name(self.country_dict, 'U'), 'Country code not found')

--- a/AlumniProject/AlumniProject/social_tracker/tests/test_country_codes.py
+++ b/AlumniProject/AlumniProject/social_tracker/tests/test_country_codes.py
@@ -1,5 +1,8 @@
 from django.test import TestCase
-from social_tracker.utils.country_code_resolver import load_country_dict, get_country_name
+from social_tracker.utils.country_code_resolver import (
+    load_country_dict,
+    get_country_name,
+)
 
 
 class CountryCodeTests(TestCase):
@@ -9,11 +12,15 @@ class CountryCodeTests(TestCase):
         cls.country_dict = load_country_dict()
 
     def test_valid_country_code(self):
-        self.assertEqual(get_country_name(self.country_dict, 'US'), 'United States 🇺🇸')
-        self.assertEqual(get_country_name(self.country_dict, 'CA'), 'Canada 🇨🇦')
+        self.assertEqual(get_country_name(self.country_dict, "US"), "United States 🇺🇸")
+        self.assertEqual(get_country_name(self.country_dict, "CA"), "Canada 🇨🇦")
 
     def test_invalid_country_code(self):
-        self.assertEqual(get_country_name(self.country_dict, 'ZZ'), 'Country code not found')
+        self.assertEqual(
+            get_country_name(self.country_dict, "ZZ"), "Country code not found"
+        )
 
     def test_partial_country_code(self):
-        self.assertEqual(get_country_name(self.country_dict, 'U'), 'Country code not found')
+        self.assertEqual(
+            get_country_name(self.country_dict, "U"), "Country code not found"
+        )

--- a/AlumniProject/AlumniProject/social_tracker/utils/country_code_resolver.py
+++ b/AlumniProject/AlumniProject/social_tracker/utils/country_code_resolver.py
@@ -1,0 +1,22 @@
+import os
+
+def load_country_dict():
+    """
+    Loads the country codes and names from a text file.
+    Returns a dictionary where keys are codes and values are country names.
+    """
+    country_dict = {}
+    file_path = os.path.join(os.path.dirname(__file__), "country_codes_list.txt")
+    with open(file_path, 'r', encoding='utf-8') as file:
+        for line in file:
+            code, name = line.strip().split('&')
+            country_dict[code] = name
+    return country_dict
+
+
+
+def get_country_name(country_dict, code):
+    """
+    Retrieves the country name from the dictionary using the code.
+    """
+    return country_dict.get(code, 'Country code not found')

--- a/AlumniProject/AlumniProject/social_tracker/utils/country_code_resolver.py
+++ b/AlumniProject/AlumniProject/social_tracker/utils/country_code_resolver.py
@@ -3,8 +3,10 @@ import os
 
 def load_country_dict():
     """
-    Loads the country codes and names from a text file.
-    Returns a dictionary where keys are codes and values are country names.
+    Load country codes and names from a the text file country_codes_list.txt in this same directory
+
+    Returns:
+        dict: A dictionary where keys are country codes (str) and values are country names (str)
     """
     country_dict = {}
     file_path = os.path.join(os.path.dirname(__file__), "country_codes_list.txt")
@@ -17,6 +19,13 @@ def load_country_dict():
 
 def get_country_name(country_dict, code):
     """
-    Retrieves the country name from the dictionary using the code.
+    Retrieve the country name from the dictionary using a given code
+
+    Args:
+        country_dict (dict): The dictionary returned by load_country_dict
+        code (str): The country code to look up
+
+    Returns:
+        str: The name of the country if found, otherwise "Country code not found".
     """
     return country_dict.get(code, "Country code not found")

--- a/AlumniProject/AlumniProject/social_tracker/utils/country_code_resolver.py
+++ b/AlumniProject/AlumniProject/social_tracker/utils/country_code_resolver.py
@@ -1,5 +1,6 @@
 import os
 
+
 def load_country_dict():
     """
     Loads the country codes and names from a text file.
@@ -7,16 +8,15 @@ def load_country_dict():
     """
     country_dict = {}
     file_path = os.path.join(os.path.dirname(__file__), "country_codes_list.txt")
-    with open(file_path, 'r', encoding='utf-8') as file:
+    with open(file_path, "r", encoding="utf-8") as file:
         for line in file:
-            code, name = line.strip().split('&')
+            code, name = line.strip().split("&")
             country_dict[code] = name
     return country_dict
-
 
 
 def get_country_name(country_dict, code):
     """
     Retrieves the country name from the dictionary using the code.
     """
-    return country_dict.get(code, 'Country code not found')
+    return country_dict.get(code, "Country code not found")

--- a/AlumniProject/AlumniProject/social_tracker/utils/country_codes_list.txt
+++ b/AlumniProject/AlumniProject/social_tracker/utils/country_codes_list.txt
@@ -1,0 +1,246 @@
+AD&Andorra 🇦🇩
+AE&United Arab Emirates 🇦🇪
+AF&Afghanistan 🇦🇫
+AG&Antigua 🇦🇬
+AI&Anguilla 🇦🇮
+AL&Albania 🇦🇱
+AM&Armenia 🇦🇲
+AN&Netherlands Antilles
+AO&Angola 🇦🇴
+AQ&Antarctica 🇦🇶
+AR&Argentina 🇦🇷
+AS&American Samoa 🇦🇸
+AT&Austria 🇦🇹
+AU&Australia 🇦🇺
+AW&Aruba 🇦🇼
+AX&Aland Islands 🇦🇽
+AZ&Azerbaijan 🇦🇿
+BA&Bosnia and Herzegovina 🇧🇦
+BB&Barbados 🇧🇧
+BD&Bangladesh 🇧🇩
+BE&Belgium 🇧🇪
+BF&Burkina Faso 🇧🇫
+BG&Bulgaria 🇧🇬
+BH&Bahrain 🇧🇭
+BI&Burundi 🇧🇮
+BJ&Benin 🇧🇯
+BL&Saint Barthélemy 🇧🇱
+BM&Bermuda 🇧🇲
+BN&Brunei 🇧🇳
+BO&Bolivia 🇧🇴
+BQ&Bonaire, Sint Eustatius and Saba 🇧🇶
+BR&Brazil 🇧🇷
+BS&The Bahamas 🇧🇸
+BT&Bhutan 🇧🇹
+BV&Bouvet Island 🇧🇻
+BW&Botswana 🇧🇼
+BY&Belarus 🇧🇾
+BZ&Belize 🇧🇿
+CA&Canada 🇨🇦
+CC&Cocos (Keeling) Islands 🇨🇨
+CD&Democratic Republic of the Congo 🇨🇩
+CF&Central African Republic 🇨🇫
+CG&Republic of the Congo 🇨🇬
+CH&Switzerland 🇨🇭
+CI&Côte d'Ivoire 🇨🇮
+CK&Cook Islands 🇨🇰
+CL&Chile 🇨🇱
+CM&Cameroon 🇨🇲
+CN&China 🇨🇳
+CO&Colombia 🇨🇴
+CR&Costa Rica 🇨🇷
+CV&Cape Verde 🇨🇻
+CW&Curaçao 🇨🇼
+CX&Christmas Island 🇨🇽
+CY&Cyprus 🇨🇾
+CZ&Czech Republic 🇨🇿
+DE&Germany 🇩🇪
+DJ&Djibouti 🇩🇯
+DK&Denmark 🇩🇰
+DM&Dominica 🇩🇲
+DO&Dominican Republic 🇩🇴
+DZ&Algeria 🇩🇿
+EC&Ecuador 🇪🇨
+EE&Estonia 🇪🇪
+EG&Egypt 🇪🇬
+EH&Western Sahara 🇪🇭
+ER&Eritrea 🇪🇷
+ES&Spain 🇪🇸
+ET&Ethiopia 🇪🇹
+FI&Finland 🇫🇮
+FJ&Fiji 🇫🇯
+FK&Falkland Islands 🇫🇰
+FM&Federated States of Micronesia 🇫🇲
+FO&Faroe Islands 🇫🇴
+FR&France 🇫🇷
+GA&Gabon 🇬🇦
+GB&United Kingdom 🇬🇧
+GD&Grenada 🇬🇩
+GE&Georgia 🇬🇪
+GF&French Guiana 🇬🇫
+GG&Guernsey 🇬🇬
+GH&Ghana 🇬🇭
+GI&Gibraltar 🇬🇮
+GL&Greenland 🇬🇱
+GM&The Gambia 🇬🇲
+GN&Guinea 🇬🇳
+GP&Guadeloupe 🇬🇵
+GQ&Equatorial Guinea 🇬🇶
+GR&Greece 🇬🇷
+GS&South Georgia and the South Sandwich Islands 🇬🇸
+GT&Guatemala 🇬🇹
+GU&Guam 🇬🇺
+GW&Guinea-Bissau 🇬🇼
+GY&Guyana 🇬🇾
+HK&Hong Kong 🇭🇰
+HM&Heard Island and McDonald Islands 🇭🇲
+HN&Honduras 🇭🇳
+HR&Croatia 🇭🇷
+HT&Haiti 🇭🇹
+HU&Hungary 🇭🇺
+ID&Indonesia 🇮🇩
+IE&Ireland 🇮🇪
+IL&Israel 🇮🇱
+IM&Isle Of Man 🇮🇲
+IN&India 🇮🇳
+IO&British Indian Ocean Territory 🇮🇴
+IQ&Iraq 🇮🇶
+IS&Iceland 🇮🇸
+IT&Italy 🇮🇹
+JE&Jersey 🇯🇪
+JM&Jamaica 🇯🇲
+JO&Jordan 🇯🇴
+JP&Japan 🇯🇵
+KE&Kenya 🇰🇪
+KG&Kyrgyzstan 🇰🇬
+KH&Cambodia 🇰🇭
+KI&Kiribati 🇰🇮
+KM&Comoros 🇰🇲
+KN&Saint Kitts and Nevis 🇰🇳
+KR&South Korea 🇰🇷
+KW&Kuwait 🇰🇼
+KY&Cayman Islands 🇰🇾
+KZ&Kazakhstan 🇰🇿
+LA&Laos 🇱🇦
+LB&Lebanon 🇱🇧
+LC&St. Lucia 🇱🇨
+LI&Liechtenstein 🇱🇮
+LK&Sri Lanka 🇱🇰
+LR&Liberia 🇱🇷
+LS&Lesotho 🇱🇸
+LT&Lithuania 🇱🇹
+LU&Luxembourg 🇱🇺
+LV&Latvia 🇱🇻
+LY&Libya 🇱🇾
+MA&Morocco 🇲🇦
+MC&Monaco 🇲🇨
+MD&Moldova 🇲🇩
+ME&Montenegro 🇲🇪
+MF&Saint Martin 🇲🇫
+MG&Madagascar 🇲🇬
+MH&Marshall Islands 🇲🇭
+MK&Macedonia 🇲🇰
+ML&Mali 🇲🇱
+MM&Myanmar 🇲🇲
+MN&Mongolia 🇲🇳
+MO&Macau 🇲🇴
+MP&Northern Mariana Islands 🇲🇵
+MQ&Martinique 🇲🇶
+MR&Mauritania 🇲🇷
+MS&Montserrat 🇲🇸
+MT&Malta 🇲🇹
+MU&Mauritius 🇲🇺
+MV&Maldives 🇲🇻
+MW&Malawi 🇲🇼
+MX&Mexico 🇲🇽
+MY&Malaysia 🇲🇾
+MZ&Mozambique 🇲🇿
+NA&Namibia 🇳🇦
+NC&New Caledonia 🇳🇨
+NE&Niger 🇳🇪
+NF&Norfolk Island 🇳🇫
+NG&Nigeria 🇳🇬
+NI&Nicaragua 🇳🇮
+NL&Netherlands 🇳🇱
+NO&Norway 🇳🇴
+NP&Nepal 🇳🇵
+NR&Nauru 🇳🇷
+NU&Niue 🇳🇺
+NZ&New Zealand 🇳🇿
+OM&Oman 🇴🇲
+PA&Panama 🇵🇦
+PE&Peru 🇵🇪
+PF&French Polynesia 🇵🇫
+PG&Papua New Guinea 🇵🇬
+PH&Philippines 🇵🇭
+PK&Pakistan 🇵🇰
+PL&Poland 🇵🇱
+PM&Saint Pierre and Miquelon 🇵🇲
+PN&Pitcairn 🇵🇳
+PR&Puerto Rico 🇵🇷
+PS&Palestine 🇵🇸
+PT&Portugal 🇵🇹
+PW&Palau 🇵🇼
+PY&Paraguay 🇵🇾
+QA&Qatar 🇶🇦
+RE&Réunion 🇷🇪
+RO&Romania 🇷🇴
+RS&Serbia 🇷🇸
+RU&Russia 🇷🇺
+RW&Rwanda 🇷🇼
+SA&Saudi Arabia 🇸🇦
+SB&Solomon Islands 🇸🇧
+SC&Seychelles 🇸🇨
+SE&Sweden 🇸🇪
+SG&Singapore 🇸🇬
+SH&Saint Helena 🇸🇭
+SI&Slovenia 🇸🇮
+SJ&Svalbard and Jan Mayen 🇸🇯
+SK&Slovakia 🇸🇰
+SL&Sierra Leone 🇸🇱
+SM&San Marino 🇸🇲
+SN&Senegal 🇸🇳
+SO&Somalia 🇸🇴
+SR&Suriname 🇸🇷
+SS&South Sudan 🇸🇸
+ST&Sao Tome and Principe 🇸🇹
+SV&El Salvador 🇸🇻
+SX&Sint Maarten 🇸🇽
+SZ&Swaziland 🇸🇿
+TC&Turks and Caicos Islands 🇹🇨
+TD&Chad 🇹🇩
+TF&French Southern Territories 🇹🇫
+TG&Togo 🇹🇬
+TH&Thailand 🇹🇭
+TJ&Tajikistan 🇹🇯
+TK&Tokelau 🇹🇰
+TL&Timor-Leste 🇹🇱
+TM&Turkmenistan 🇹🇲
+TN&Tunisia 🇹🇳
+TO&Tonga 🇹🇴
+TR&Turkey 🇹🇷
+TT&Trinidad and Tobago 🇹🇹
+TV&Tuvalu 🇹🇻
+TW&Taiwan 🇹🇼
+TZ&Tanzania 🇹🇿
+UA&Ukraine 🇺🇦
+UG&Uganda 🇺🇬
+UM&United States Minor Outlying Islands 🇺🇲
+US&United States 🇺🇸
+UY&Uruguay 🇺🇾
+UZ&Uzbekistan 🇺🇿
+VA&Vatican City 🇻🇦
+VC&Saint Vincent and the Grenadines 🇻🇨
+VE&Venezuela 🇻🇪
+VG&British Virgin Islands 🇻🇬
+VI&US Virgin Islands 🇻🇮
+VN&Vietnam 🇻🇳
+VU&Vanuatu 🇻🇺
+WF&Wallis and Futuna 🇼🇫
+WS&Samoa 🇼🇸
+XK&Kosovo 🇽🇰
+YE&Yemen 🇾🇪
+YT&Mayotte 🇾🇹
+ZA&South Africa 🇿🇦
+ZM&Zambia 🇿🇲
+ZW&Zimbabwe 🇿🇼

--- a/AlumniProject/AlumniProject/social_tracker/views.py
+++ b/AlumniProject/AlumniProject/social_tracker/views.py
@@ -272,7 +272,10 @@ def demographics_view(request):
     response_data = {
         "ageRanges": {item["age_range"]: item["num_interactions"] for item in age_data},
         "topCountries": [
-            {"country": get_country_name(country_dict, item["name"]), "count": item["num_interactions"]}
+            {
+                "country": get_country_name(country_dict, item["name"]),
+                "count": item["num_interactions"],
+            }
             for item in country_data
         ],
         "topCities": [

--- a/AlumniProject/AlumniProject/social_tracker/views.py
+++ b/AlumniProject/AlumniProject/social_tracker/views.py
@@ -10,6 +10,7 @@ from .utils.get_instagram_data import (
     get_city_demographics,
     get_age_demographics,
 )
+from .utils.country_code_resolver import load_country_dict, get_country_name
 from .models import Country, City, Age
 from .utils.write_database_to_csv import export_posts_to_csv
 from django.views.decorators.csrf import csrf_exempt
@@ -267,10 +268,11 @@ def demographics_view(request):
         .order_by("-num_interactions")[:5]
         .values("name", "num_interactions")
     )
+    country_dict = load_country_dict()
     response_data = {
         "ageRanges": {item["age_range"]: item["num_interactions"] for item in age_data},
         "topCountries": [
-            {"country": item["name"], "count": item["num_interactions"]}
+            {"country": get_country_name(country_dict, item["name"]), "count": item["num_interactions"]}
             for item in country_data
         ],
         "topCities": [
@@ -278,7 +280,6 @@ def demographics_view(request):
             for item in city_data
         ],
     }
-    print(response_data)
     return JsonResponse({"success": True, "data": response_data})
 
 

--- a/AlumniProject/AlumniProject/templates/demographics.html
+++ b/AlumniProject/AlumniProject/templates/demographics.html
@@ -265,19 +265,6 @@
         cityList.appendChild(li);
       });
     }
-
-    // Function to map country abbreviations to full names
-    function getFullCountryName(abbreviation) {
-      const countryNames = {
-        US: "United States",
-        MX: "Mexico",
-        MW: "Malawi",
-        SA: "Saudi Arabia",
-        DE: "Germany"
-        // Add more mappings as needed
-      };
-      return countryNames[abbreviation] || abbreviation;
-    }
   </script>
 </body>
 </html>

--- a/AlumniProject/AlumniProject/templates/demographics.html
+++ b/AlumniProject/AlumniProject/templates/demographics.html
@@ -235,7 +235,7 @@
         li.className = "list-group-item d-flex justify-content-between align-items-center";
         
         // Add ranking number and full country name
-        const countryName = getFullCountryName(item.country); // Function to get full country name
+        const countryName = item.country; // Function to get full country name
         li.textContent = `${index + 1}. ${countryName}`;
 
         const badge = document.createElement("span");


### PR DESCRIPTION
# Overview

**Type of Change:** New Feature

**Summary:** Added in a translation of the country codes that we get from Instagram into the actual country names. Let me know what you guys think about the little flags by the names, I am totally open to getting rid of that but thought it would be fun. Quick change either way. 

## UI/UX Implementation

<img width="586" alt="image" src="https://github.com/user-attachments/assets/54fccf91-c936-409d-98a8-ba3b4a5c661c" />

## Model Updates
None

### Data Models
None

### Object-Oriented Models
None

## End-to-End Testing Instructions
Open up the demographics page. You should see the actual country names now instead of just the country codes like US CA MX.
