### PR TITLE
Time of day and Day of the week frontend

### DIFF
--- a/AlumniProject/AlumniProject/AlumniProject/urls.py
+++ b/AlumniProject/AlumniProject/AlumniProject/urls.py
@@ -26,7 +26,6 @@ from social_tracker.views import user_login
 from social_tracker import views
 
 
-
 urlpatterns = [
     path("", views.token_landing, name="token_landing"),
     path("posts/", views.home, name="home"),

--- a/AlumniProject/AlumniProject/AlumniProject/urls.py
+++ b/AlumniProject/AlumniProject/AlumniProject/urls.py
@@ -25,6 +25,8 @@ from django.urls import path
 from social_tracker.views import user_login
 from social_tracker import views
 
+
+
 urlpatterns = [
     path("", views.token_landing, name="token_landing"),
     path("posts/", views.home, name="home"),

--- a/AlumniProject/AlumniProject/social_tracker/views.py
+++ b/AlumniProject/AlumniProject/social_tracker/views.py
@@ -488,6 +488,7 @@ def get_days_of_week(request):
         }
     )
 
+
 def get_days_of_week_data_helper(request):
     """
     Calls the existing get_days_of_week view and gets the data dictionary.
@@ -502,11 +503,11 @@ def account_info(request):
     """
     Handles the Account Info page and displays two charts with post engagement trends.
 
-    Based on the selected metrics from the dropdowns, this view pulls average engagement data 
-    by 2-hour time blocks and by day of the week. It prepares the labels and values for each chart 
+    Based on the selected metrics from the dropdowns, this view pulls average engagement data
+    by 2-hour time blocks and by day of the week. It prepares the labels and values for each chart
     and passes everything to the template so the charts can render using Chart.js.
 
-    The page responds to optional GET parameters of 'metric' for the time block chart and 
+    The page responds to optional GET parameters of 'metric' for the time block chart and
     'day_metric' for the day of week chart.
     """
     metric = request.GET.get("metric", "likes")
@@ -522,7 +523,7 @@ def account_info(request):
     elif metric == "shares":
         _, block_data = get_avg_shares_by_time_block()
     else:
-        _, block_data = get_avg_likes_by_time_block()  #default
+        _, block_data = get_avg_likes_by_time_block()  # default
 
     time_labels = [row["block"] for row in block_data]
     time_values = [row[f"avg_{metric}"] for row in block_data]
@@ -538,7 +539,6 @@ def account_info(request):
         "labels": time_labels,
         "values": time_values,
         "label": f"Average {metric.capitalize()} per Time Block",
-
         "day_metric": day_metric,
         "labels_day": day_labels,
         "values_day": day_values,

--- a/AlumniProject/AlumniProject/social_tracker/views.py
+++ b/AlumniProject/AlumniProject/social_tracker/views.py
@@ -497,7 +497,6 @@ def account_info(request):
     Renders the account information page, including a bar chart showing 
     average engagement (likes, comments, saves, or shares) by time of day.
 
-    The metric shown is selected using the "metric" query parameter.
     Defaults to 'likes' if no metric is specified.
     """
     metric = request.GET.get("metric", "likes")

--- a/AlumniProject/AlumniProject/social_tracker/views.py
+++ b/AlumniProject/AlumniProject/social_tracker/views.py
@@ -27,8 +27,6 @@ from social_tracker.utils.get_time_of_day_statistics import (
 )
 
 
-
-
 """
     Handles user login functionality.
 
@@ -494,7 +492,7 @@ def get_days_of_week(request):
 @login_required
 def account_info(request):
     """
-    Renders the account information page, including a bar chart showing 
+    Renders the account information page, including a bar chart showing
     average engagement (likes, comments, saves, or shares) by time of day.
 
     Defaults to 'likes' if no metric is specified.

--- a/AlumniProject/AlumniProject/social_tracker/views.py
+++ b/AlumniProject/AlumniProject/social_tracker/views.py
@@ -546,6 +546,6 @@ def account_info(request):
         "labels_day": day_labels,
         "values_day": day_values,
         "day_label": f"Average {day_metric.capitalize()} per Day",
-        "users": users
+        "users": users,
     }
     return render(request, "account_info.html", context)

--- a/AlumniProject/AlumniProject/social_tracker/views.py
+++ b/AlumniProject/AlumniProject/social_tracker/views.py
@@ -535,6 +535,8 @@ def account_info(request):
     day_index = ["likes", "comments", "shares", "saves"].index(day_metric) + 1
     day_values = [day_data[day][day_index] for day in day_labels]
 
+    users = InstagramUser.objects.order_by("-num_comments")
+
     context = {
         "metric": metric,
         "labels": time_labels,
@@ -544,5 +546,6 @@ def account_info(request):
         "labels_day": day_labels,
         "values_day": day_values,
         "day_label": f"Average {day_metric.capitalize()} per Day",
+        "users": users
     }
     return render(request, "account_info.html", context)

--- a/AlumniProject/AlumniProject/templates/account_info.html
+++ b/AlumniProject/AlumniProject/templates/account_info.html
@@ -49,7 +49,7 @@
       border-radius: 10px;
       box-shadow: 0 0 20px rgba(0, 0, 0, 0.2);
       margin-top: 50px;
-      max-width: 1200px; /* was 800px */
+      max-width: 1200px;
     }
 
     .form-select {
@@ -75,32 +75,43 @@
   </nav>
 
   <div class="container">
-    <h1 class="mb-4">Average Time of Day Interactions</h1>
-
-    <!-- Metric Selection -->
-    <form method="get" id="metric-form" class="mb-4">
-      <label for="metric" class="form-label">Select Metric:</label>
-      <select name="metric" id="metric" class="form-select" onchange="document.getElementById('metric-form').submit()">
-        <option value="likes" {% if metric == "likes" %}selected{% endif %}>Likes</option>
-        <option value="comments" {% if metric == "comments" %}selected{% endif %}>Comments</option>
-        <option value="saves" {% if metric == "saves" %}selected{% endif %}>Saves</option>
-        <option value="shares" {% if metric == "shares" %}selected{% endif %}>Shares</option>
-      </select>
-    </form>
-
-    <!-- Charts -->
-    <!-- Chart Row -->
     <div class="row">
-      <!-- First chart (left side) -->
+      <!-- Time of Day chart (left side) -->
       <div class="col-md-6">
+        <h2 class="text-center mb-3">Average Time of Day Interactions</h2>
+        <div class="d-flex justify-content-end mb-3">
+          <form method="get" id="metric-form" class="d-flex align-items-center">
+            <label for="metric" class="me-2 mb-0">Select Metric:</label>
+            <select name="metric" id="metric" class="form-select" style="width: auto;" onchange="document.getElementById('metric-form').submit()">
+              <option value="likes" {% if metric == "likes" %}selected{% endif %}>Likes</option>
+              <option value="comments" {% if metric == "comments" %}selected{% endif %}>Comments</option>
+              <option value="saves" {% if metric == "saves" %}selected{% endif %}>Saves</option>
+              <option value="shares" {% if metric == "shares" %}selected{% endif %}>Shares</option>
+            </select>
+          </form>
+        </div>
         <div class="chart-container">
           <canvas id="barChart" width="400" height="400"></canvas>
         </div>
       </div>
 
-      <!-- Placeholder for second chart (right side) -->
+      <!-- Day of week chart (right side) -->
       <div class="col-md-6">
-        <!-- Future chart goes here -->
+        <h2 class="text-center mb-3">Average Day of Week Metrics</h2>
+        <div class="d-flex justify-content-end mb-3">
+          <form method="get" id="day-metric-form" class="d-flex align-items-center">
+            <label for="day_metric" class="me-2 mb-0">Select Metric:</label>
+            <select name="day_metric" id="day_metric" class="form-select" style="width: auto;" onchange="document.getElementById('day-metric-form').submit()">
+              <option value="likes" {% if day_metric == "likes" %}selected{% endif %}>Likes</option>
+              <option value="comments" {% if day_metric == "comments" %}selected{% endif %}>Comments</option>
+              <option value="saves" {% if day_metric == "saves" %}selected{% endif %}>Saves</option>
+              <option value="shares" {% if day_metric == "shares" %}selected{% endif %}>Shares</option>
+            </select>
+          </form>
+        </div>
+        <div class="chart-container">
+          <canvas id="dayChart" width="400" height="400"></canvas>
+        </div>
       </div>
     </div>
   </div>
@@ -108,8 +119,10 @@
   <!-- JSON Data -->
   {{ labels|json_script:"labels-data" }}
   {{ values|json_script:"values-data" }}
+  {{ labels_day|json_script:"labels-day-data" }}
+  {{ values_day|json_script:"values-day-data" }}
 
-  <!-- Chart.js Script -->
+  <!-- Time of day chart Script -->
   <script>
     const labels = JSON.parse(document.getElementById("labels-data").textContent);
     const values = JSON.parse(document.getElementById("values-data").textContent);
@@ -123,6 +136,33 @@
           label: "{{ label }}",
           data: values,
           backgroundColor: "rgba(54, 162, 235, 0.6)",
+        }]
+      },
+      options: {
+        responsive: true,
+        scales: {
+          y: {
+            beginAtZero: true
+          }
+        }
+      }
+    });
+  </script>
+
+  <!-- Day of week chart Script -->
+  <script>
+    const labelsDay = JSON.parse(document.getElementById("labels-day-data").textContent);
+    const valuesDay = JSON.parse(document.getElementById("values-day-data").textContent);
+
+    const ctxDay = document.getElementById("dayChart").getContext("2d");
+    const dayChart = new Chart(ctxDay, {
+      type: "bar",
+      data: {
+        labels: labelsDay,
+        datasets: [{
+          label: "{{ day_label }}",
+          data: valuesDay,
+          backgroundColor: "rgba(255, 99, 132, 0.6)"
         }]
       },
       options: {

--- a/AlumniProject/AlumniProject/templates/account_info.html
+++ b/AlumniProject/AlumniProject/templates/account_info.html
@@ -1,15 +1,19 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Account Info</title>
 
   <!-- Font Awesome (for icons) -->
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
 
   <!-- Bootstrap -->
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
+
+  <!-- Chart.js -->
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+
   <style>
     :root {
       --founders-blue: #003b70;
@@ -20,7 +24,7 @@
 
     body {
       background: linear-gradient(135deg, #003b70, #0074c8);
-      height: 100vh;
+      min-height: 100vh;
       color: white;
       margin: 0;
       padding: 0;
@@ -32,6 +36,7 @@
       border: none;
       font-size: 1.2rem;
     }
+
     .nav-tabs .nav-link.active {
       color: var(--torero-blue);
       background-color: var(--alcala-white);
@@ -42,21 +47,20 @@
       background-color: var(--torero-blue);
       padding: 2rem;
       border-radius: 10px;
-      box-shadow: 0 0 20px rgba(0,0,0,0.2);
+      box-shadow: 0 0 20px rgba(0, 0, 0, 0.2);
       margin-top: 50px;
-      max-width: 600px;
+      max-width: 800px;
     }
 
-    .btn {
-      background-color: var(--founders-blue);
-      color: white;
-      border: none;
-      padding: 10px 20px;
-      border-radius: 5px;
-      margin: 5px;
+    .form-select {
+      max-width: 200px;
     }
-    .btn:hover {
-      background-color: var(--immaculata-blue);
+
+    .chart-container {
+      background-color: var(--alcala-white);
+      padding: 1rem;
+      border-radius: 8px;
+      color: black;
     }
   </style>
 </head>
@@ -71,9 +75,55 @@
   </nav>
 
   <div class="container">
-    <h1>Account Information</h1>
-    <!-- Content for Account Info will go here -->
+    <h1 class="mb-4">Average Time of Day Interactions</h1>
+
+    <!-- Metric Selection -->
+    <form method="get" id="metric-form" class="mb-4">
+      <label for="metric" class="form-label">Select Metric:</label>
+      <select name="metric" id="metric" class="form-select" onchange="document.getElementById('metric-form').submit()">
+        <option value="likes" {% if metric == "likes" %}selected{% endif %}>Likes</option>
+        <option value="comments" {% if metric == "comments" %}selected{% endif %}>Comments</option>
+        <option value="saves" {% if metric == "saves" %}selected{% endif %}>Saves</option>
+        <option value="shares" {% if metric == "shares" %}selected{% endif %}>Shares</option>
+      </select>
+    </form>
+
+    <!-- Chart -->
+    <div class="chart-container">
+      <canvas id="barChart" width="800" height="400"></canvas>
+    </div>
   </div>
+
+  <!-- JSON Data -->
+  {{ labels|json_script:"labels-data" }}
+  {{ values|json_script:"values-data" }}
+
+  <!-- Chart.js Script -->
+  <script>
+    const labels = JSON.parse(document.getElementById("labels-data").textContent);
+    const values = JSON.parse(document.getElementById("values-data").textContent);
+
+    const ctx = document.getElementById("barChart").getContext("2d");
+    const chart = new Chart(ctx, {
+      type: "bar",
+      data: {
+        labels: labels,
+        datasets: [{
+          label: "{{ label }}",
+          data: values,
+          backgroundColor: "rgba(54, 162, 235, 0.6)",
+        }]
+      },
+      options: {
+        responsive: true,
+        scales: {
+          y: {
+            beginAtZero: true
+          }
+        }
+      }
+    });
+  </script>
 
   <!-- Bootstrap JS -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>

--- a/AlumniProject/AlumniProject/templates/account_info.html
+++ b/AlumniProject/AlumniProject/templates/account_info.html
@@ -49,7 +49,7 @@
       border-radius: 10px;
       box-shadow: 0 0 20px rgba(0, 0, 0, 0.2);
       margin-top: 50px;
-      max-width: 800px;
+      max-width: 1200px; /* was 800px */
     }
 
     .form-select {
@@ -88,9 +88,20 @@
       </select>
     </form>
 
-    <!-- Chart -->
-    <div class="chart-container">
-      <canvas id="barChart" width="800" height="400"></canvas>
+    <!-- Charts -->
+    <!-- Chart Row -->
+    <div class="row">
+      <!-- First chart (left side) -->
+      <div class="col-md-6">
+        <div class="chart-container">
+          <canvas id="barChart" width="400" height="400"></canvas>
+        </div>
+      </div>
+
+      <!-- Placeholder for second chart (right side) -->
+      <div class="col-md-6">
+        <!-- Future chart goes here -->
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
# Overview

**Type of Change:** New Feature

**Summary:** I created the frontend for getting the time of day and day of the week metrics. This front end gets the data from the backend functions connor and I created. It displays engagement data for time of day by 2-hour time blocks and 7 days for day of the week, using a bar chart to show average likes, comments, shares, and saves. 

## UI/UX Implementation

![image](https://github.com/user-attachments/assets/702436bb-f1eb-4a48-b171-37c35b9b7ab8)


I added two bar charts and two headers that showcase the metric that is being shown on the chart. There is a dropdown that selects the metric and the bar chart has appropriate Y values to fit the data. The two dropdowns are independent of eachother and will maintain upon refreshing the page.

## Model Updates

This section describes changes that were made to the models used by your application.

### Data Models

No changes made.

### Object-Oriented Models

No changes made.

## End-to-End Testing Instructions

Once the user is logged in, navigate to the Account info page. The values should automatically update with each refresh. Select the different metrics to confirm that the data makes sense.