### PR TITLE
Fixed routing issue between post comments and account stats

### DIFF
--- a/AlumniProject/AlumniProject/templates/post-details.html
+++ b/AlumniProject/AlumniProject/templates/post-details.html
@@ -212,7 +212,7 @@
     <!-- If "Post Info" is considered active, we do this: -->
     <a class="nav-link" href="{% url 'token_page' %}">Token</a>
     <a class="nav-link active" aria-current="page" href="{% url 'home' %}">Post Info</a>
-    <a class="nav-link" href="account.html">Account Info</a>
+    <a class="nav-link" href="{% url 'account-info' %}">Account Info</a>
     <a class="nav-link" href="{% url 'demographics' %}">Demographic Info</a>
   </nav>
 


### PR DESCRIPTION
# Overview

**Type of Change:** 
Bug Fix

**Summary:** 
Changed the routing from relative to absolute
## UI/UX Implementation
No changes made

## Model Updates

No changes made

### Data Models
No changes made

### Object-Oriented Models
No changes made

## End-to-End Testing Instructions

Go to post comments page then use the header to navigate to account stats. Now it works